### PR TITLE
Add InitByName

### DIFF
--- a/device.go
+++ b/device.go
@@ -31,6 +31,21 @@ func Init(devicePath string) (*Device, error) {
 	return &Device{cryptDevice: cryptDevice}, nil
 }
 
+// InitByName initializes a crypt device from provided active device 'name'.
+// Returns a pointer to the newly allocated Device or any error encountered.
+// C equivalent: crypt_init_by_name
+func InitByName(name string) (*Device, error) {
+	activeCryptDeviceName := C.CString(name)
+	defer C.free(unsafe.Pointer(activeCryptDeviceName))
+
+	var cryptDevice *C.struct_crypt_device
+	if err := int(C.crypt_init_by_name(&cryptDevice, activeCryptDeviceName)); err < 0 {
+		return nil, &Error{functionName: "crypt_init_by_name", code: err}
+	}
+
+	return &Device{cryptDevice: cryptDevice}, nil
+}
+
 // Free releases crypt device context and used memory.
 // C equivalent: crypt_free
 func (device *Device) Free() bool {

--- a/device_test.go
+++ b/device_test.go
@@ -23,6 +23,14 @@ func Test_Device_Init_Fails_If_Device_Is_Not_Found(test *testing.T) {
 	testWrapper.AssertErrorCodeEquals(err, -15)
 }
 
+func Test_Device_InitByName_Fails_If_Device_Is_Not_Active(test *testing.T) {
+	testWrapper := TestWrapper{test}
+
+	_, err := InitByName("nonExistingMappedDevice")
+	testWrapper.AssertError(err)
+	testWrapper.AssertErrorCodeEquals(err, -19)
+}
+
 func Test_Device_Free_Works(test *testing.T) {
 	testWrapper := TestWrapper{test}
 

--- a/plain_test.go
+++ b/plain_test.go
@@ -22,6 +22,29 @@ func Test_Plain_ActivateByPassphrase_Deactivate(test *testing.T) {
 	device.Free()
 }
 
+func Test_Plain_ActivateByPassphrase_Free_InitByName_Deactivate(test *testing.T) {
+	testWrapper := TestWrapper{test}
+
+	device, err := Init(DevicePath)
+	testWrapper.AssertNoError(err)
+
+	err = device.Format(Plain{Hash: "sha256"}, GenericParams{Cipher: "aes", CipherMode: "xts-plain64", VolumeKeySize: 512 / 8})
+	testWrapper.AssertNoError(err)
+
+	err = device.ActivateByPassphrase(DevicePath, 0, PassKey, CRYPT_ACTIVATE_READONLY)
+	testWrapper.AssertNoError(err)
+
+	device.Free()
+
+	device, err = InitByName(DevicePath)
+	testWrapper.AssertNoError(err)
+
+	err = device.Deactivate(DevicePath)
+	testWrapper.AssertNoError(err)
+
+	device.Free()
+}
+
 func Test_Plain_ActivateByVolumeKey_Deactivate(test *testing.T) {
 	testWrapper := TestWrapper{test}
 


### PR DESCRIPTION
Allows initializing a crypt device from an active (mapped) device. I would like to write tests around this.. However, I noticed that no other test ever successfully activates a device so not sure how to go about that,